### PR TITLE
Add README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+[Utopia: A Fleet Builder for Star Trek Attack Wing](https://kfnexus.github.io/staw-utopia/index.html)
+=====================================================================================================
+
+
+Getting Started
+---------------
+
+* ensure [Node.js](http://nodejs.org) is installed
+* ensure [Grunt](https://gruntjs.com/getting-started) is installed (typically
+  via `npm install -g grunt-cli`)
+* `npm install` downloads dependencies
+* `npm start` generates application files
+
+The repository's directory structure should be largely self-explanatory:
+
+* `src` contains all source files (e.g. JavaScript and CSS)
+
+  Attack Wing data resides in `src/data`.
+
+* `staw-utopia` contains application files generated via `npm start`
+
+  **NB:** These files should _not_ be edited manually; any changes here will be
+          overwritten by `npm start`.
+
+  If you want to inspect the generated `staw-utopia/data/data.json` file, you
+  might use a JSON prettifier (e.g. [JSTool](http://www.sunjw.us/jstoolnpp/) for
+  [Notepad++](https://notepad-plus-plus.org)).

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "homepage": "https://github.com/ComaToes/staw-utopia#readme",
   "scripts": {
+    "start": "grunt",
     "data": "npm run lint-data && npm run generate-data",
     "generate-data": "node ./src/data/index.js",
     "lint-data": "eslint --fix 'src/data/**/*.js'"

--- a/package.json
+++ b/package.json
@@ -1,16 +1,23 @@
 {
   "name": "staw-utopia",
   "version": "1.0.0",
+  "description": "A Fleet Builder for Star Trek Attack Wing",
+  "author": "ComaToes",
+  "contributors": [
+    "KFNEXUS",
+    "jsterner73",
+    "CrazyVulcan",
+    "wiegeabo"
+  ],
+  "license": "LGPLv3",
+  "homepage": "https://github.com/KFNEXUS/KFNEXUS.github.io#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ComaToes/staw-utopia.git"
+    "url": "git+https://github.com/KFNEXUS/KFNEXUS.github.io.git"
   },
-  "author": "",
-  "license": "LGPLv3",
   "bugs": {
-    "url": "https://github.com/ComaToes/staw-utopia/issues"
+    "url": "https://github.com/KFNEXUS/KFNEXUS.github.io/issues"
   },
-  "homepage": "https://github.com/ComaToes/staw-utopia#readme",
   "scripts": {
     "start": "grunt",
     "data": "npm run lint-data && npm run generate-data",


### PR DESCRIPTION
See [my fork](https://github.com/FND/KFNEXUS.github.io/tree/docs#readme) for what this looks like.

In the process, updated package metadata. (I hope I got the author/contributors right.)

As mentioned in #38, this should render [the wiki instructions](https://github.com/KFNEXUS/KFNEXUS.github.io/wiki) obsolete. (I do not seem to have permission to edit the wiki myself, so deprecating that page would be up to @jsterner73 or @CrazyVulcan.)